### PR TITLE
feat: 为 markdown 中的外部链接旁显示外部链接图标

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,6 +74,9 @@ export default defineConfig({
     /* Algolia DocSearch 配置 */
     algolia,
 
+    /* 是否在 markdown 中的外部链接旁显示外部链接图标 */
+    externalLinkIcon: true,
+
     docFooter: {
       prev: "上一篇",
       next: "下一篇",


### PR DESCRIPTION
如图这是一个外部链接，但是因为点击后就没颜色了，所以鼠标不移动到上面的话无法发现这是一个链接

![image](https://github.com/user-attachments/assets/b709d715-bb66-4581-8050-a84d95d5f565)
